### PR TITLE
Allow to set custom ViewController title

### DIFF
--- a/Classes/VTAcknowledgementsViewController.m
+++ b/Classes/VTAcknowledgementsViewController.m
@@ -75,6 +75,7 @@ static NSString *const VTCocoaPodsURLString = @"http://cocoapods.org";
 
 - (void)commonInitWithAcknowledgementsPlistPath:(NSString *)acknowledgementsPlistPath
 {
+    self.title = self.class.localizedTitle;    
     NSDictionary *root = [NSDictionary dictionaryWithContentsOfFile:acknowledgementsPlistPath];
     NSArray *preferenceSpecifiers = root[@"PreferenceSpecifiers"];
     if (preferenceSpecifiers.count >= 2) {
@@ -135,8 +136,6 @@ static NSString *const VTCocoaPodsURLString = @"http://cocoapods.org";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-
-    self.title = self.class.localizedTitle;
 
     if (self.navigationController.viewControllers.count <= 1) {
         UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone


### PR DESCRIPTION
Some people like me want the AcknowledgementsViewController to have a custom title like "Licenses" or "Software Licenses" (or custom localized versions thereof) instead of "Acknowledgements.

By setting the `title` to the `localizedTitle` in the common initializer the functionaloty is unchanged, but developers are able to set `UIViewController`'s `title` property after initialization:

```
VTAcknowledgementsViewController *licensesViewController = [VTAcknowledgementsViewController acknowledgementsViewController];
licensesViewController.title = NSLocalizedString(@"my_custom_licenses_title", nil);
[self.navigationController pushViewController:licensesViewController animated:YES];
```
