### PR TITLE
Properly deselect row upon view re-appearance

### DIFF
--- a/Classes/VTAcknowledgementsViewController.m
+++ b/Classes/VTAcknowledgementsViewController.m
@@ -221,6 +221,8 @@ static const CGFloat VTLabelMargin          = 20;
                                                                               action:@selector(dismissViewController:)];
         self.navigationItem.leftBarButtonItem = item;
     }
+    
+    [self.tableView deselectRowAtIndexPath:[self.tableView indexPathForSelectedRow] animated:animated];
 }
 
 - (void)viewDidAppear:(BOOL)animated


### PR DESCRIPTION
Currently the cell selection tends to bug when the user interactively dismisses an acknowledgement controller. It either stays or lags behind. Fixed by dismissing it manually on view appearance.
