### PR TITLE
Show dismiss button only when presented modally

### DIFF
--- a/Classes/VTAcknowledgementsViewController.m
+++ b/Classes/VTAcknowledgementsViewController.m
@@ -219,6 +219,14 @@ static const CGFloat VTLabelMargin          = 20;
     self.tableView.tableFooterView = footerView;
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+
+    [self.tableView deselectRowAtIndexPath:self.tableView.indexPathForSelectedRow
+                                  animated:animated];
+}
+
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
@@ -250,7 +258,7 @@ static const CGFloat VTLabelMargin          = 20;
 
 - (IBAction)dismissViewController:(id)sender
 {
-    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - Table view data source
@@ -278,7 +286,6 @@ static const CGFloat VTLabelMargin          = 20;
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    [tableView deselectRowAtIndexPath:indexPath animated:YES];
     VTAcknowledgement *acknowledgement = self.acknowledgements[indexPath.row];
     VTAcknowledgementViewController *viewController = [[VTAcknowledgementViewController alloc] initWithTitle:acknowledgement.title text:acknowledgement.text];
     viewController.textViewFont = self.licenseTextViewFont;


### PR DESCRIPTION
- Modify the configuration of dismiss button so that it only appears when the controller is root view controller and presented modally.

I notice that there were [discussions](https://github.com/vtourraine/VTAcknowledgementsViewController/pull/13#commitcomment-5544466) about `navigationController.viewControllers` count being 0 in `viewDidLoad:`. I've tested in storyboard and it works fine with the configuration in `viewDidLoad:`. Not sure if there are other circumstances that would cause the count to be 0.
