### PR TITLE
Prevent cell collapsing on iOS 7+

### DIFF
--- a/Classes/VTAcknowledgementsViewController.m
+++ b/Classes/VTAcknowledgementsViewController.m
@@ -282,6 +282,11 @@ static const CGFloat VTLabelMargin = 20;
     return self.acknowledgements.count;
 }
 
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    return UITableViewAutomaticDimension;
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:VTCellIdentifier];


### PR DESCRIPTION
Since the cell does not have a height set UITableView will reset the cell to its default height in `viewWillDisappear:` (most notably when pushing a VTAcknowledgementViewController).
In most scenarios this is not a problem, but since the default font is used (iirc this is the body font of user configurable size) this will result in a weird and unnecessary UI change.

IMO the default font should not be used anyway here since header & footer use `[UIFont systemFontOfSize:12]` and the VTAcknowledgementViewController defaults to `[UIFont systemFontOfSize:17]` which makes the default UI strangely inconsistent.

While it should not change behaviour pre-iOS7–due to the lack of an emulator or a device in my possession running it–I did test this explicitly. 