### PR TITLE
Import Pods-acknowledgements.plist automatically

### DIFF
--- a/Classes/VTAcknowledgementsViewController.m
+++ b/Classes/VTAcknowledgementsViewController.m
@@ -57,7 +57,9 @@ static const CGFloat VTLabelMargin = 20;
 
 + (NSString *)defaultAcknowledgementsPlistPath
 {
-    return [self acknowledgementsPlistPathForName:VTDefaultAcknowledgementsPlistName];
+    NSBundle* plistBundle = [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:VTDefaultAcknowledgementsPlistName ofType:@"bundle"]];
+    
+    return [plistBundle pathForResource:VTDefaultAcknowledgementsPlistName ofType:@"plist"];
 }
 
 + (instancetype)acknowledgementsViewController

--- a/Pods-acknowledgements.plist
+++ b/Pods-acknowledgements.plist
@@ -1,0 +1,1 @@
+../Target Support Files/Pods/Pods-acknowledgements.plist

--- a/VTAcknowledgementsViewController.podspec.json
+++ b/VTAcknowledgementsViewController.podspec.json
@@ -18,6 +18,9 @@
   },
   "source_files": "Classes/*.{h,m}",
   "resources": "VTAcknowledgementsViewController.bundle",
+  "resource_bundles": {
+    "Pods-acknowledgements": "Pods-acknowledgements.plist"
+  },
   "requires_arc": true,
   "platforms": {
     "ios": "5.0"


### PR DESCRIPTION
With this PR users of the pod don't have to import manually the Pods-acknowledgements.plist.

It's done by the VTAcknowledgementsViewController pod itself via creating a resource bundle with the plist. The plist in the repo is a symlink to the one created by CocoaPods. (So the solution has one weakness: if the generated plist is moved to somewhere else by CocoaPods folks.)

If you accept the PR, to successfully lint the updated pod you should replace the symlink with a real plist file while you're submitting the new release to the Specs repo. See: https://github.com/rivera-ernesto/AcknowledgementsBundle/pull/2#issuecomment-67097526