### PR TITLE
Fixing issue where acknowledgement content was scrolled up slightly

### DIFF
--- a/Classes/VTAcknowledgementViewController.m
+++ b/Classes/VTAcknowledgementViewController.m
@@ -54,6 +54,7 @@
     if ([textView respondsToSelector:@selector(setTextContainerInset:)]) {
         textView.textContainerInset = UIEdgeInsetsMake(12, 10, 12, 10);
     }
+    textView.contentOffset = CGPointZero;
 
     self.view = textView;
 


### PR DESCRIPTION
While the default value of a UITextView's contentOffset should be `CGPointZero` I was seeing (iOS 9) the content scrolled slightly up, and under the navigation bar. Resetting the `contentOffset` after `textContainerInset` corrects this issue.