### PR TITLE
Fixed swift naming conflict

### DIFF
--- a/Classes/VTAcknowledgementsViewController.h
+++ b/Classes/VTAcknowledgementsViewController.h
@@ -68,7 +68,7 @@
 
  @return A newly created `VTAcknowledgementsViewController` instance.
  */
-+ (nullable instancetype)acknowledgementsViewController;
++ (nullable instancetype)acknowledgementsViewController NS_SWIFT_NAME(instantiate());
 
 /**
  The localized version of “Acknowledgements”.

--- a/Classes/VTAcknowledgementsViewController.h
+++ b/Classes/VTAcknowledgementsViewController.h
@@ -68,7 +68,7 @@
 
  @return A newly created `VTAcknowledgementsViewController` instance.
  */
-+ (nullable instancetype)acknowledgementsViewController NS_SWIFT_NAME(instantiate());
++ (nullable instancetype)acknowledgementsViewController NS_SWIFT_NAME(acknowledgementsViewController());
 
 /**
  The localized version of “Acknowledgements”.


### PR DESCRIPTION
I'm not sure about the method name, but this is a possible fix for #41.

Apple added the possibility to change the method-selector for Swift using the `NS_SWIFT_NAME()` macro.
An AcknowledgementsViewController can now be created using `VTAcknowledgementsViewController.instantiate()`.

More info about the `NS_SWIFT_NAME()`-macro can be found here: https://developer.apple.com/library/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html
Hope this helps :)