### PR TITLE
Fixes Swift Issues accessing VTAcknowledgement and umbrella header issues

### DIFF
--- a/Classes/VTAcknowledgementsViewController.h
+++ b/Classes/VTAcknowledgementsViewController.h
@@ -27,8 +27,8 @@
 #import <UIKit/UIKit.h>
 #endif
 
-@class VTAcknowledgement;
-
+#import "VTAcknowledgementsParser.h"
+#import "VTAcknowledgement.h"
 
 /**
  `VTAcknowledgementsViewController` is a subclass of `UITableViewController` that displays

--- a/Classes/VTAcknowledgementsViewController.m
+++ b/Classes/VTAcknowledgementsViewController.m
@@ -23,8 +23,6 @@
 
 #import "VTAcknowledgementsViewController.h"
 #import "VTAcknowledgementViewController.h"
-#import "VTAcknowledgementsParser.h"
-#import "VTAcknowledgement.h"
 
 #if !TARGET_OS_TV
 #if __has_feature(modules)


### PR DESCRIPTION
When using Swift the `VTAcknowledgementsViewController.h` effectively works as Umbrella Header for the framework. Because `VTAcknowledgement.h` and `VTAcknowledgementsParser.h` aren't exposed those classes are not accessible to Swift, rendering the view controller's `acknowledgements` property unusable. 

This was a blocker for me as I'm aggregating both CocoaPods and Carthage dependencies and am using this property to filter/map/sort them.

By including those imports inside the header Swift actually finds them and they're fully usable by an integrator. This also lints those nasty warnings:

<img width="270" alt="screenshot 2016-12-21 20 54 48" src="https://cloud.githubusercontent.com/assets/126418/21384882/6a985654-c7c0-11e6-8500-2965462bd78c.png">
