### PR TITLE
Fix bundle handling for dynamic frameworks

### DIFF
--- a/Classes/VTAcknowledgementsViewController.m
+++ b/Classes/VTAcknowledgementsViewController.m
@@ -161,20 +161,20 @@ static const CGFloat VTFooterBottomMargin = 20;
 {
     static NSBundle *bundle = nil;
     if (!bundle) {
-        NSString *bundlePath = [NSBundle.mainBundle pathForResource:@"VTAcknowledgementsViewController" ofType:@"bundle"];
+        NSString *bundlePath = [[NSBundle bundleForClass:VTAcknowledgementsViewController.class] pathForResource:@"VTAcknowledgementsViewController" ofType:@"bundle"];
         bundle = [NSBundle bundleWithPath:bundlePath];
-
-        NSString *language = NSLocale.preferredLanguages.count? NSLocale.preferredLanguages.firstObject: @"en";
+        
+        NSString *language = NSBundle.mainBundle.preferredLocalizations.firstObject ?: @"en";
         if (![bundle.localizations containsObject:language]) {
             language = [language componentsSeparatedByString:@"-"].firstObject;
         }
         if ([bundle.localizations containsObject:language]) {
             bundlePath = [bundle pathForResource:language ofType:@"lproj"];
         }
-
+        
         bundle = [NSBundle bundleWithPath:bundlePath] ?: NSBundle.mainBundle;
     }
-
+    
     defaultString = [bundle localizedStringForKey:key value:defaultString table:nil];
     return [NSBundle.mainBundle localizedStringForKey:key value:defaultString table:nil];
 }

--- a/Classes/VTAcknowledgementsViewController.m
+++ b/Classes/VTAcknowledgementsViewController.m
@@ -171,10 +171,10 @@ static const CGFloat VTFooterBottomMargin = 20;
         if ([bundle.localizations containsObject:language]) {
             bundlePath = [bundle pathForResource:language ofType:@"lproj"];
         }
-        
+
         bundle = [NSBundle bundleWithPath:bundlePath] ?: NSBundle.mainBundle;
     }
-    
+
     defaultString = [bundle localizedStringForKey:key value:defaultString table:nil];
     return [NSBundle.mainBundle localizedStringForKey:key value:defaultString table:nil];
 }


### PR DESCRIPTION
MOD using main bundle's `.preferredLocalizations` instead of `NSLocale`'s `preferredLanguages`

----

I found that the lookup doesn't work when installing this pod as a dynamic framework. 
While i was at it, i also switched to `.preferredLocalizations` as this will retrieve the app's language setting as opposed to the system one (unless i'm gravely mistaken).