### PR TITLE
Update podspec iOS version to 9.1

### DIFF
--- a/VTAcknowledgementsViewController.podspec.json
+++ b/VTAcknowledgementsViewController.podspec.json
@@ -20,7 +20,7 @@
   "resources": "VTAcknowledgementsViewController.bundle",
   "requires_arc": true,
   "platforms": {
-    "ios": "9.1",
+    "ios": "8.0",
     "tvos": "9.0"
   }
 }

--- a/VTAcknowledgementsViewController.podspec.json
+++ b/VTAcknowledgementsViewController.podspec.json
@@ -20,7 +20,7 @@
   "resources": "VTAcknowledgementsViewController.bundle",
   "requires_arc": true,
   "platforms": {
-    "ios": "5.0",
+    "ios": "9.1",
     "tvos": "9.0"
   }
 }


### PR DESCRIPTION
Updated podspec iOS version to 9.1, which is the current deployment target of the xcodeproject.
When installing from Cocoapods in other projects, it was compiled for iOS 5, so the library has many warnings due to unavailable methods being used in earlier versions.

Since the Xcode project is already set to iOS 9.1, this is indeed a very small change.