### PR TITLE
Remove deprecated method (tvOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1 (work in progress)
+
+- Remove deprecated `preferredFocusedView` method for tvOS
+
+
 ## 2.0 (15 March 2021)
 
 - Update `VTAcknowledgementsViewController` to detect URLs in header and footer

--- a/Classes/VTAcknowledgementViewController.m
+++ b/Classes/VTAcknowledgementViewController.m
@@ -87,8 +87,4 @@ const CGFloat VTLeftRightDefaultMargin = 10;
     textView.textContainerInset = UIEdgeInsetsMake(VTTopBottomDefaultMargin, self.view.layoutMargins.left, VTTopBottomDefaultMargin, self.view.layoutMargins.right);
 }
 
-- (UIView *)preferredFocusedView {
-    return self.textView;
-}
-
 @end


### PR DESCRIPTION
Removes deprecated `preferredFocusedView` method (tvOS).

Implementing `preferredFocusedView` is no longer necessary since tvOS automatically picks up the text view for its “focus” engine.